### PR TITLE
Fix example php code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,10 +98,10 @@ The flexibility is unparalleled and the possibilities are endless.
 The dispatch class itself can be instantiated with just a few dependencies.
 
 ```php
-$router = new \Aura\Router\Router;
+$router = (new \Aura\Router\RouterFactory())->newInstance();
 $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-$action_factory = new \Aol\Atc\ActionFactory('Your\\Namespace\\Prefix');
-$presenter = new \Aol\Atc\Presenter(__DIR__ . '/your/view/dir/';
+$action_factory = new \Aol\Atc\ActionFactory('Your\\Namespace\\Prefix\\');
+$presenter = new \Aol\Atc\Presenter(__DIR__ . '/your/view/dir/');
 $event_dispatcher = new \Aol\Atc\EventDispatcher;
 $exception_handler = new \Aol\Atc\EventHandlers\DispatchErrorHandler;
 


### PR DESCRIPTION
- Use RouterFactory, this way copy paste of your code works.
- Adds trailing `\\` to namespace, otherwise routes would have to be prefixed with `\\` and nobody wants that in their route names.
- Adds closing `)` because nobody likes syntax errors in example code.
